### PR TITLE
Remove all deprecated transitionalId usages

### DIFF
--- a/lib/intercode.js
+++ b/lib/intercode.js
@@ -64,7 +64,7 @@ class Intercode {
     getUser() {
         const query = gql`query getUser {
             currentUser {
-                id: transitionalId
+                id
                 name
                 email
             }
@@ -75,15 +75,15 @@ class Intercode {
     async getPermissions(userId) {
 
         const query = gql`query getPermissions($conventionDomain: String!, $userId: ID!) {
-            user(transitionalId: $userId) {
+            user(id: $userId) {
                 privileges
             }
 
             convention: conventionByDomain(domain: $conventionDomain) {
-                user_con_profile_by_user_id(transitionalUserId: $userId) {
-                    id: transitionalId
+                user_con_profile_by_user_id(userId: $userId) {
+                    id
                     staff_positions {
-                        id: transitionalId
+                        id
                         name
                     }
                 }
@@ -103,13 +103,13 @@ class Intercode {
     async getMemberEvents(userId) {
         const query = gql`query getMemberEvents($userId: ID!, $conventionDomain: String!) {
             convention: conventionByDomain(domain: $conventionDomain) {
-                user_con_profile_by_user_id(transitionalUserId: $userId) {
+                user_con_profile_by_user_id(userId: $userId) {
                     team_members {
-                        id: transitionalId
+                        id
                         display_team_member
 
                         event {
-                            id: transitionalId
+                            id
                             title
                             length_seconds
                             event_category {
@@ -118,20 +118,20 @@ class Intercode {
                             }
 
                             runs {
-                                id: transitionalId
+                                id
                                 starts_at
                                 ends_at
                                 rooms {
-                                    id: transitionalId
+                                    id
                                     name
                                 }
                             }
 
                             team_members {
-                                id: transitionalId
+                                id
                                 display_team_member
                                 user_con_profile {
-                                    id: transitionalId
+                                    id
                                     name_without_nickname
                                     email
                                 }
@@ -152,19 +152,19 @@ class Intercode {
     async getRun(eventId, runId) {
         const query = gql`query getRun($conventionDomain: String!, $eventId: ID!, $runId: ID!) {
             convention: conventionByDomain(domain: $conventionDomain) {
-                event(transitionalId: $eventId) {
-                    run(transitionalId: $runId) {
-                        id: transitionalId
+                event(id: $eventId) {
+                    run(id: $runId) {
+                        id
                         starts_at
                         ends_at
 
                         rooms {
-                            id: transitionalId
+                            id
                             name
                         }
 
                         event {
-                            id: transitionalId
+                            id
                             title
                             length_seconds
                             event_category {
@@ -172,10 +172,10 @@ class Intercode {
                                 team_member_name
                             }
                             team_members {
-                                id: transitionalId
+                                id
                                 display_team_member
                                 user_con_profile {
-                                    id: transitionalId
+                                    id
                                     name_without_nickname
                                     email
                                 }
@@ -204,7 +204,7 @@ class Intercode {
         const query = gql`query getEvents($conventionDomain: String!) {
             convention: conventionByDomain(domain: $conventionDomain) {
                 events {
-                    id: transitionalId
+                    id
                     title
                     event_category {
                         name
@@ -212,19 +212,19 @@ class Intercode {
                     }
                     length_seconds
                     runs {
-                        id: transitionalId
+                        id
                         starts_at
                         ends_at
                         rooms {
-                            id: transitionalId
+                            id
                             name
                         }
                     }
                     team_members {
-                        id: transitionalId
+                        id
                         display_team_member
                         user_con_profile {
-                            id: transitionalId
+                            id
                             name_without_nickname
                             email
                         }
@@ -243,7 +243,7 @@ class Intercode {
         const query = gql`query getRooms($conventionDomain: String!) {
             convention: conventionByDomain(domain: $conventionDomain) {
                 rooms {
-                    id: transitionalId
+                    id
                     name
                 }
             }


### PR DESCRIPTION
This finishes the work started in the other Intercode API upgrade PR.  Now that IDs in production all use the ID type, we can go back to the regular ID fields and arguments without breaking anything.